### PR TITLE
heater:

### DIFF
--- a/klippy/extras/heaters.py
+++ b/klippy/extras/heaters.py
@@ -198,7 +198,11 @@ class ControlPID:
                           + temp_diff) / self.min_deriv_time
         # Calculate accumulated temperature "error"
         temp_err = target_temp - temp
-        temp_integ = self.prev_temp_integ + temp_err * time_diff
+        if target_temp == 0:
+            temp_integ = 0
+            self.prev_temp_integ = 0
+        else:
+            temp_integ = self.prev_temp_integ + temp_err * time_diff
         temp_integ = max(0., min(self.temp_integ_max, temp_integ))
         # Calculate output
         co = self.Kp*temp_err + self.Ki*temp_integ - self.Kd*temp_deriv


### PR DESCRIPTION
prev_temp_int would hold its value through on-off cycle of the heater, resulting in inconsistent PID behavior between first run and later runs. Later step changes would have more overshoot due to more accumulated integral gain.

This resets the values of prev_temp_int and temp_int when target==0, resulting in more consistent overshoot & pid behavior between on/off cycles of heaters.

Signed-off-by: Trey Zarecor <zarecor60@gmail.com>